### PR TITLE
Support for organizing the feeds into groups

### DIFF
--- a/assets/rc
+++ b/assets/rc
@@ -19,7 +19,7 @@ map Esc --state log focus feeds
 map C-c confirm "Are you sure you want to quit?" --default true quit
 map q confirm "Are you sure you want to quit?" --default true quit
 map C-r refresh
-map Delete --state feeds confirm "Are you sure you want to delete this feed? Your history will be deleted." delete-feed
+map Delete --state feeds confirm "Are you sure you want to delete this item? This cannot be undone." delete
 map o --state feeds open-link feed
 map o --state episodes open-link episode
 map . repeat-command

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -1,7 +1,7 @@
 use crate::datasource::{DataProvider, NewFeedMetadata, QueryError};
 use crate::model::{
     Episode, EpisodeId, EpisodePlaybackData, EpisodeStatus, EpisodeSummary, EpisodeSummaryStatus,
-    EpisodesListMetadata, Feed, FeedId, FeedStatus, FeedSummary, GroupSummary,
+    EpisodesListMetadata, Feed, FeedId, FeedStatus, FeedSummary, GroupId, GroupSummary,
 };
 use crate::rss_client::{fetch_feed, WritableFeed};
 use crate::EpisodesQuery;
@@ -303,6 +303,7 @@ pub enum FeedUpdateRequest {
     AddFeed(NewFeedMetadata),
     DeleteFeed(FeedId),
     RenameFeed(FeedId, String),
+    RenameGroup(GroupId, String),
     Update(UpdateQuery),
     AddArchive(FeedId, String),
     SetStatus(EpisodesQuery, EpisodeStatus),
@@ -360,6 +361,11 @@ impl Handler<FeedUpdateRequest> for Library {
             FeedUpdateRequest::RenameFeed(feed_id, name) => {
                 if let Err(error) = self.data_provider.rename_feed(feed_id, name) {
                     log::error!(target: "sql", "cannot rename feed, {}", error);
+                }
+            }
+            FeedUpdateRequest::RenameGroup(group_id, name) => {
+                if let Err(error) = self.data_provider.rename_group(group_id, name) {
+                    log::error!(target: "sql", "cannot rename group, {}", error);
                 }
             }
             FeedUpdateRequest::SetStatus(query, status) => {

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -304,6 +304,7 @@ pub enum FeedUpdateRequest {
     AddGroup(String),
     DeleteFeed(FeedId),
     DeleteGroup(GroupId),
+    SetGroupPosition(GroupId, usize),
     RenameFeed(FeedId, String),
     RenameGroup(GroupId, String),
     Update(UpdateQuery),
@@ -377,6 +378,11 @@ impl Handler<FeedUpdateRequest> for Library {
             FeedUpdateRequest::DeleteGroup(group_id) => {
                 if let Err(error) = self.data_provider.delete_group(group_id) {
                     log::error!(target: "sql", "cannot delete group, {}", error);
+                }
+            }
+            FeedUpdateRequest::SetGroupPosition(group_id, position) => {
+                if let Err(error) = self.data_provider.set_group_position(group_id, position) {
+                    log::error!(target: "sql", "cannot change group position, {}", error);
                 }
             }
             FeedUpdateRequest::RenameFeed(feed_id, name) => {

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -307,6 +307,7 @@ pub enum FeedUpdateRequest {
     RenameFeed(FeedId, String),
     RenameGroup(GroupId, String),
     Update(UpdateQuery),
+    SetGroup(GroupId, FeedId),
     AddArchive(FeedId, String),
     SetStatus(EpisodesQuery, EpisodeStatus),
     SetHidden(EpisodesQuery, bool),
@@ -328,6 +329,7 @@ impl Handler<FeedUpdateRequest> for Library {
                     }
                 }
             }
+
             FeedUpdateRequest::AddArchive(feed_id, feed_url) => {
                 self.schedule_update(vec![(feed_id, feed_url)], ctx);
             }
@@ -414,6 +416,11 @@ impl Handler<FeedUpdateRequest> for Library {
             FeedUpdateRequest::ReverseFeedOrder(feed_id) => {
                 if let Err(error) = self.data_provider.reverse_feed_order(feed_id) {
                     log::error!(target: "sql", "cannot reverse order, {}", error);
+                }
+            }
+            FeedUpdateRequest::SetGroup(group_id, feed_id) => {
+                if let Err(error) = self.data_provider.add_feed_to_group(group_id, feed_id) {
+                    log::error!(target: "sql", "cannot assign group, {}", error);
                 }
             }
         }

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -287,6 +287,7 @@ pub enum FeedUpdateRequest {
     Subscribe(Recipient<FeedUpdateNotification>),
     AddFeed(NewFeedMetadata),
     DeleteFeed(FeedId),
+    RenameFeed(FeedId, String),
     Update(UpdateQuery),
     AddArchive(FeedId, String),
     SetStatus(EpisodesQuery, EpisodeStatus),
@@ -339,6 +340,11 @@ impl Handler<FeedUpdateRequest> for Library {
                     Err(error) => {
                         log::error!(target: "sql", "cannot delete feed, {}", error);
                     }
+                }
+            }
+            FeedUpdateRequest::RenameFeed(feed_id, name) => {
+                if let Err(error) = self.data_provider.rename_feed(feed_id, name) {
+                    log::error!(target: "sql", "cannot rename feed, {}", error);
                 }
             }
             FeedUpdateRequest::SetStatus(query, status) => {

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -303,6 +303,7 @@ pub enum FeedUpdateRequest {
     AddFeed(NewFeedMetadata),
     AddGroup(String),
     DeleteFeed(FeedId),
+    DeleteGroup(GroupId),
     RenameFeed(FeedId, String),
     RenameGroup(GroupId, String),
     Update(UpdateQuery),
@@ -369,6 +370,12 @@ impl Handler<FeedUpdateRequest> for Library {
                     Err(error) => {
                         log::error!(target: "sql", "cannot delete feed, {}", error);
                     }
+                }
+            }
+
+            FeedUpdateRequest::DeleteGroup(group_id) => {
+                if let Err(error) = self.data_provider.delete_group(group_id) {
+                    log::error!(target: "sql", "cannot delete group, {}", error);
                 }
             }
             FeedUpdateRequest::RenameFeed(feed_id, name) => {

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -215,6 +215,17 @@ impl Library {
                             .status(EpisodeSummaryStatus::New);
                         feed_summary.new_count =
                             library.data_provider.count_episodes(new_episodes_query)?;
+
+                        let feed = library.data_provider.get_feed(feed_id)?;
+                        if let Some((overriden, title)) = feed.and_then(|feed| {
+                            let overridden = feed.title_overriden;
+                            feed.title.map(|title| (overridden, title))
+                        }) {
+                            if overriden {
+                                feed_summary.title = title;
+                            }
+                        }
+
                         library.notify_update_listener(FeedUpdateNotification::UpdateFinished(
                             feed_id,
                             FeedUpdateResult::Updated(feed_summary),

--- a/hedgehog-library/src/actor.rs
+++ b/hedgehog-library/src/actor.rs
@@ -372,7 +372,6 @@ impl Handler<FeedUpdateRequest> for Library {
                     }
                 }
             }
-
             FeedUpdateRequest::DeleteGroup(group_id) => {
                 if let Err(error) = self.data_provider.delete_group(group_id) {
                     log::error!(target: "sql", "cannot delete group, {}", error);

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -57,6 +57,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.get_update_sources(update)
     }
 
+    fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
+        self.data_provider.rename_feed(feed_id, name)
+    }
+
     fn get_new_episodes_count(
         &mut self,
         feed_ids: HashSet<FeedId>,

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -80,6 +80,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.rename_group(group_id, name)
     }
 
+    fn delete_group(&mut self, group_id: GroupId) -> DbResult<()> {
+        self.data_provider.delete_group(group_id)
+    }
+
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>> {
         self.data_provider.get_episode(episode_id)
     }

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -88,6 +88,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.delete_group(group_id)
     }
 
+    fn set_group_position(&mut self, group_id: GroupId, position: usize) -> DbResult<()> {
+        self.data_provider.set_group_position(group_id, position)
+    }
+
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>> {
         self.data_provider.get_episode(episode_id)
     }

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -76,6 +76,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.get_group_summaries()
     }
 
+    fn add_feed_to_group(&mut self, group_id: GroupId, feed_id: FeedId) -> DbResult<()> {
+        self.data_provider.add_feed_to_group(group_id, feed_id)
+    }
+
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()> {
         self.data_provider.rename_group(group_id, name)
     }

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -53,12 +53,12 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.get_feed_opml_entries()
     }
 
-    fn get_update_sources(&mut self, update: UpdateQuery) -> DbResult<Vec<(FeedId, String)>> {
-        self.data_provider.get_update_sources(update)
+    fn get_group_summaries(&mut self) -> DbResult<Vec<crate::model::GroupSummary>> {
+        self.data_provider.get_group_summaries()
     }
 
-    fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
-        self.data_provider.rename_feed(feed_id, name)
+    fn get_update_sources(&mut self, update: UpdateQuery) -> DbResult<Vec<(FeedId, String)>> {
+        self.data_provider.get_update_sources(update)
     }
 
     fn get_new_episodes_count(
@@ -66,6 +66,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         feed_ids: HashSet<FeedId>,
     ) -> DbResult<HashMap<FeedId, usize>> {
         self.data_provider.get_new_episodes_count(feed_ids)
+    }
+
+    fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
+        self.data_provider.rename_feed(feed_id, name)
     }
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>> {

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -53,10 +53,6 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
         self.data_provider.get_feed_opml_entries()
     }
 
-    fn get_group_summaries(&mut self) -> DbResult<Vec<crate::model::GroupSummary>> {
-        self.data_provider.get_group_summaries()
-    }
-
     fn get_update_sources(&mut self, update: UpdateQuery) -> DbResult<Vec<(FeedId, String)>> {
         self.data_provider.get_update_sources(update)
     }
@@ -70,6 +66,14 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
 
     fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
         self.data_provider.rename_feed(feed_id, name)
+    }
+
+    fn create_group(&mut self, name: &str) -> DbResult<Option<GroupId>> {
+        self.data_provider.create_group(name)
+    }
+
+    fn get_group_summaries(&mut self) -> DbResult<Vec<crate::model::GroupSummary>> {
+        self.data_provider.get_group_summaries()
     }
 
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()> {

--- a/hedgehog-library/src/cache.rs
+++ b/hedgehog-library/src/cache.rs
@@ -1,7 +1,7 @@
 use crate::datasource::{DataProvider, DbResult, EpisodeWriter};
 use crate::model::{
     Episode, EpisodeId, EpisodePlaybackData, EpisodeStatus, EpisodeSummary, EpisodesListMetadata,
-    Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary,
+    Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary, GroupId,
 };
 use crate::{EpisodesQuery, NewFeedMetadata, UpdateQuery};
 use std::collections::{HashMap, HashSet};
@@ -70,6 +70,10 @@ impl<D: DataProvider> DataProvider for InMemoryCache<D> {
 
     fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
         self.data_provider.rename_feed(feed_id, name)
+    }
+
+    fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()> {
+        self.data_provider.rename_group(group_id, name)
     }
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>> {

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -3,6 +3,7 @@ use crate::metadata::{EpisodeMetadata, FeedMetadata};
 use crate::model::{
     Episode, EpisodeId, EpisodePlaybackData, EpisodeStatus, EpisodeSummary, EpisodeSummaryStatus,
     EpisodesListMetadata, Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary, FeedView, GroupId,
+    GroupSummary,
 };
 use std::collections::{HashMap, HashSet};
 use std::marker::Unpin;
@@ -127,6 +128,8 @@ pub trait DataProvider: Unpin {
         feed_ids: HashSet<FeedId>,
     ) -> DbResult<HashMap<FeedId, usize>>;
     fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()>;
+
+    fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>>;
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>>;
     fn get_episode_playback_data(

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -80,13 +80,14 @@ impl EpisodesQuery {
         self
     }
 
-    pub fn from_feed_view(feed_id: FeedView<FeedId>) -> Self {
+    pub fn from_feed_view(feed_id: FeedView<FeedId, GroupId>) -> Self {
         match feed_id {
             FeedView::All => EpisodesQuery::default().include_feed_title(),
             FeedView::New => EpisodesQuery::default()
                 .status(EpisodeSummaryStatus::New)
                 .include_feed_title(),
             FeedView::Feed(feed_id) => EpisodesQuery::default().feed_id(feed_id),
+            FeedView::Group(feed_id) => EpisodesQuery::default().group_id(feed_id),
         }
     }
 }

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -130,6 +130,7 @@ pub trait DataProvider: Unpin {
     ) -> DbResult<HashMap<FeedId, usize>>;
     fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()>;
 
+    fn create_group(&mut self, name: &str) -> DbResult<Option<GroupId>>;
     fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>>;
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()>;
 

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -132,6 +132,7 @@ pub trait DataProvider: Unpin {
 
     fn create_group(&mut self, name: &str) -> DbResult<Option<GroupId>>;
     fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>>;
+    fn add_feed_to_group(&mut self, group_id: GroupId, feed_id: FeedId) -> DbResult<()>;
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()>;
     fn delete_group(&mut self, group_id: GroupId) -> DbResult<()>;
 

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -119,6 +119,7 @@ pub trait DataProvider: Unpin {
         &mut self,
         feed_ids: HashSet<FeedId>,
     ) -> DbResult<HashMap<FeedId, usize>>;
+    fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()>;
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>>;
     fn get_episode_playback_data(

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -135,6 +135,7 @@ pub trait DataProvider: Unpin {
     fn add_feed_to_group(&mut self, group_id: GroupId, feed_id: FeedId) -> DbResult<()>;
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()>;
     fn delete_group(&mut self, group_id: GroupId) -> DbResult<()>;
+    fn set_group_position(&mut self, group_id: GroupId, position: usize) -> DbResult<()>;
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>>;
     fn get_episode_playback_data(

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -133,6 +133,7 @@ pub trait DataProvider: Unpin {
     fn create_group(&mut self, name: &str) -> DbResult<Option<GroupId>>;
     fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>>;
     fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()>;
+    fn delete_group(&mut self, group_id: GroupId) -> DbResult<()>;
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>>;
     fn get_episode_playback_data(

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -131,6 +131,7 @@ pub trait DataProvider: Unpin {
     fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()>;
 
     fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>>;
+    fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()>;
 
     fn get_episode(&mut self, episode_id: EpisodeId) -> DbResult<Option<Episode>>;
     fn get_episode_playback_data(

--- a/hedgehog-library/src/datasource.rs
+++ b/hedgehog-library/src/datasource.rs
@@ -2,7 +2,7 @@ use crate::actor::UpdateQuery;
 use crate::metadata::{EpisodeMetadata, FeedMetadata};
 use crate::model::{
     Episode, EpisodeId, EpisodePlaybackData, EpisodeStatus, EpisodeSummary, EpisodeSummaryStatus,
-    EpisodesListMetadata, Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary, FeedView,
+    EpisodesListMetadata, Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary, FeedView, GroupId,
 };
 use std::collections::{HashMap, HashSet};
 use std::marker::Unpin;
@@ -22,6 +22,7 @@ pub type DbResult<T> = Result<T, QueryError>;
 pub struct EpisodesQuery {
     pub(crate) episode_id: Option<EpisodeId>,
     pub(crate) feed_id: Option<FeedId>,
+    pub(crate) group_id: Option<GroupId>,
     pub(crate) status: Option<EpisodeSummaryStatus>,
     pub(crate) with_hidden: bool,
     pub(crate) include_feed_title: bool,
@@ -33,6 +34,7 @@ impl Default for EpisodesQuery {
         Self {
             episode_id: None,
             feed_id: None,
+            group_id: None,
             status: None,
             with_hidden: true,
             include_feed_title: false,
@@ -49,6 +51,11 @@ impl EpisodesQuery {
 
     pub fn feed_id(mut self, feed_id: FeedId) -> Self {
         self.feed_id = Some(feed_id);
+        self
+    }
+
+    pub fn group_id(mut self, group_id: GroupId) -> Self {
+        self.group_id = Some(group_id);
         self
     }
 

--- a/hedgehog-library/src/lib.rs
+++ b/hedgehog-library/src/lib.rs
@@ -13,8 +13,8 @@ mod tests;
 
 pub use actor::{
     EpisodePlaybackDataRequest, EpisodeRequest, EpisodeSummariesRequest,
-    EpisodesListMetadataRequest, FeedRequest, FeedSummariesRequest, FeedUpdateNotification,
-    FeedUpdateRequest, FeedUpdateResult, Library, UpdateQuery,
+    EpisodesListMetadataRequest, FeedRequest, FeedSummariesRequest, FeedSummariesResponse,
+    FeedUpdateNotification, FeedUpdateRequest, FeedUpdateResult, Library, UpdateQuery,
 };
 pub use cache::InMemoryCache;
 pub use datasource::{EpisodesQuery, NewFeedMetadata, QueryError};

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -114,6 +114,11 @@ pub trait Identifiable {
     fn id(&self) -> Self::Id;
 }
 
+pub struct GroupSummary {
+    pub id: GroupId,
+    pub name: String,
+}
+
 #[derive(Debug, PartialEq)]
 pub struct FeedSummary {
     pub id: FeedId,

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -34,6 +34,7 @@ macro_rules! entity_id {
 
 entity_id!(FeedId);
 entity_id!(EpisodeId);
+entity_id!(GroupId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeedError {
@@ -120,6 +121,7 @@ pub struct FeedSummary {
     pub has_title: bool,
     pub status: FeedStatus,
     pub new_count: usize,
+    pub group_id: Option<GroupId>,
 }
 
 impl FeedSummary {
@@ -130,6 +132,7 @@ impl FeedSummary {
             title: data.title.unwrap_or(data.source),
             status: FeedStatus::Pending,
             new_count: 0,
+            group_id: None,
         }
     }
 
@@ -144,6 +147,7 @@ impl FeedSummary {
             has_title: true,
             status: FeedStatus::Loaded,
             new_count: new_episodes_count,
+            group_id: None,
         }
     }
 }

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -350,6 +350,13 @@ impl<F, G> FeedView<F, G> {
         }
     }
 
+    pub fn as_group(&self) -> Option<&G> {
+        match self {
+            FeedView::Group(group) => Some(group),
+            _ => None,
+        }
+    }
+
     pub fn as_group_mut(&mut self) -> Option<&mut G> {
         match self {
             FeedView::Group(group) => Some(group),

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -349,6 +349,13 @@ impl<F, G> FeedView<F, G> {
         }
     }
 
+    pub fn as_group_mut(&mut self) -> Option<&mut G> {
+        match self {
+            FeedView::Group(group) => Some(group),
+            _ => None,
+        }
+    }
+
     pub fn map_feed<R>(self, f: impl FnOnce(F) -> R) -> FeedView<R, G> {
         match self {
             FeedView::All => FeedView::All,

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -114,6 +114,7 @@ pub trait Identifiable {
     fn id(&self) -> Self::Id;
 }
 
+#[derive(Debug, PartialEq)]
 pub struct GroupSummary {
     pub id: GroupId,
     pub name: String,

--- a/hedgehog-library/src/model.rs
+++ b/hedgehog-library/src/model.rs
@@ -165,6 +165,7 @@ pub struct FeedOMPLEntry {
 pub struct Feed {
     pub id: FeedId,
     pub title: Option<String>,
+    pub title_overriden: bool,
     pub description: Option<String>,
     pub link: Option<String>,
     pub author: Option<String>,

--- a/hedgehog-library/src/schema/v2.sql
+++ b/hedgehog-library/src/schema/v2.sql
@@ -1,0 +1,8 @@
+CREATE TABLE groups (
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "ordering" INTEGER NOT NULL
+);
+
+ALTER TABLE feeds ADD COLUMN group_id INTEGER REFERENCES groups("id") ON DELETE SET NULL;
+ALTER TABLE feeds ADD COLUMN title_override TEXT;

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -202,6 +202,14 @@ impl DataProvider for SqliteDataProvider {
         Ok(())
     }
 
+    fn delete_group(&mut self, group_id: GroupId) -> DbResult<()> {
+        let mut statement = self
+            .connection
+            .prepare("DELETE FROM groups WHERE id = :group_id")?;
+        statement.execute(named_params! { ":group_id": group_id })?;
+        Ok(())
+    }
+
     fn get_new_episodes_count(
         &mut self,
         feed_ids: HashSet<FeedId>,

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -177,6 +177,14 @@ impl DataProvider for SqliteDataProvider {
         Ok(collect_results(items)?)
     }
 
+    fn rename_group(&mut self, group_id: GroupId, name: String) -> DbResult<()> {
+        let mut statement = self
+            .connection
+            .prepare("UPDATE groups SET name = :name WHERE id = :group_id")?;
+        statement.execute(named_params! {":name": name, ":group_id": group_id})?;
+        Ok(())
+    }
+
     fn get_new_episodes_count(
         &mut self,
         feed_ids: HashSet<FeedId>,

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -6,6 +6,7 @@ use crate::metadata::{EpisodeMetadata, FeedMetadata};
 use crate::model::{
     Episode, EpisodeId, EpisodePlaybackData, EpisodeStatus, EpisodeSummary, EpisodeSummaryStatus,
     EpisodesListMetadata, Feed, FeedId, FeedOMPLEntry, FeedStatus, FeedSummary, GroupId,
+    GroupSummary,
 };
 use rusqlite::{named_params, Connection};
 use std::collections::{HashMap, HashSet};
@@ -161,6 +162,19 @@ impl DataProvider for SqliteDataProvider {
             .prepare("UPDATE feeds SET title_override = :name WHERE id = :feed_id")?;
         statement.execute(named_params! {":name": name, ":feed_id": feed_id})?;
         Ok(())
+    }
+
+    fn get_group_summaries(&mut self) -> DbResult<Vec<GroupSummary>> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT id, name FROM groups ORDER BY ordering")?;
+        let items = statement.query_map([], |row| {
+            Ok(GroupSummary {
+                id: row.get(0)?,
+                name: row.get(1)?,
+            })
+        })?;
+        Ok(collect_results(items)?)
     }
 
     fn get_new_episodes_count(

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -152,6 +152,14 @@ impl DataProvider for SqliteDataProvider {
         }
     }
 
+    fn rename_feed(&mut self, feed_id: FeedId, name: String) -> DbResult<()> {
+        let mut statement = self
+            .connection
+            .prepare("UPDATE feeds SET title_override = :name WHERE id = :feed_id")?;
+        statement.execute(named_params! {":name": name, ":feed_id": feed_id})?;
+        Ok(())
+    }
+
     fn get_new_episodes_count(
         &mut self,
         feed_ids: HashSet<FeedId>,

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -33,7 +33,7 @@ pub struct SqliteDataProvider {
 }
 
 impl SqliteDataProvider {
-    const CURRENT_VERSION: u32 = 1;
+    const CURRENT_VERSION: u32 = 2;
 
     pub fn connect<P: AsRef<Path>>(path: P) -> Result<Self, ConnectionError> {
         let connection = Connection::open(path)?;
@@ -48,6 +48,9 @@ impl SqliteDataProvider {
         connection.execute("PRAGMA foreign_keys = ON", named_params! {})?;
         if version < 1 {
             connection.execute_batch(include_str!("schema/init.sql"))?;
+        }
+        if version < 2 {
+            connection.execute_batch(include_str!("schema/v2.sql"))?;
         }
 
         connection.pragma_update(None, "user_version", Self::CURRENT_VERSION)?;

--- a/hedgehog-library/src/sqlite.rs
+++ b/hedgehog-library/src/sqlite.rs
@@ -20,7 +20,7 @@ pub enum ConnectionError {
     #[error("Database query failed")]
     SqliteError(#[from] rusqlite::Error),
 
-    #[error("Database was updated in a newer version of hedgehog (db version: {version}, current: {version})")]
+    #[error("Database was updated in a newer version of hedgehog (db version: {version}, current: {current})")]
     VersionUnknown { version: u32, current: u32 },
 
     #[error(transparent)]

--- a/hedgehog-library/src/tests/mod.rs
+++ b/hedgehog-library/src/tests/mod.rs
@@ -69,7 +69,7 @@ async fn adding_new_feed() {
     });
     let (library, mut reciever) = create_library().await;
 
-    let summaries = library.send(FeedSummariesRequest).await.unwrap();
+    let summaries = library.send(FeedSummariesRequest).await.unwrap().feeds;
     assert_eq!(summaries.len(), 0);
 
     let source_url = format!("{}/feed.xml", mock_server.base_url());
@@ -95,7 +95,7 @@ async fn adding_new_feed() {
     assert!(updated_summary.has_title);
     assert_eq!(updated_summary.status, FeedStatus::Loaded);
 
-    let summaries = library.send(FeedSummariesRequest).await.unwrap();
+    let summaries = library.send(FeedSummariesRequest).await.unwrap().feeds;
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0], updated_summary);
 }
@@ -129,7 +129,7 @@ async fn adding_new_feed_error() {
         FeedError::HttpError(StatusCode::from_u16(404).unwrap())
     );
 
-    let summaries = library.send(FeedSummariesRequest).await.unwrap();
+    let summaries = library.send(FeedSummariesRequest).await.unwrap().feeds;
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0].id, summary.id);
     assert_eq!(summaries[0].title, source_url);

--- a/hedgehog-tui/src/cmdcontext.rs
+++ b/hedgehog-tui/src/cmdcontext.rs
@@ -1,0 +1,56 @@
+use cmdparse::{tokens::Token, CompletionResult, Parsable, Parser};
+use hedgehog_library::model::{FeedSummary, FeedView, GroupSummary};
+
+#[derive(Clone)]
+pub(crate) struct CommandContext<'a> {
+    pub(crate) feeds: &'a [FeedView<FeedSummary, GroupSummary>],
+}
+
+#[derive(Default)]
+pub(crate) struct GroupNameParser;
+
+impl<'c> Parser<CommandContext<'c>> for GroupNameParser {
+    type Value = String;
+
+    fn parse<'a>(
+        &self,
+        input: cmdparse::tokens::TokenStream<'a>,
+        ctx: CommandContext<'c>,
+    ) -> cmdparse::ParseResult<'a, Self::Value> {
+        <String as Parsable<CommandContext<'c>>>::Parser::default().parse(input, ctx)
+    }
+
+    fn complete<'a>(
+        &self,
+        input: cmdparse::tokens::TokenStream<'a>,
+        ctx: CommandContext<'c>,
+    ) -> cmdparse::CompletionResult<'a> {
+        match input.take() {
+            Some(Ok((Token::Text(text), remaining))) if remaining.is_all_consumed() => {
+                let text = text.parse_string();
+                CompletionResult::new_final(true).add_suggestions(
+                    ctx.feeds
+                        .iter()
+                        .filter_map(FeedView::as_group)
+                        .filter_map(|group| {
+                            group.name.strip_prefix(&text as &str).and_then(|key| {
+                                match key.is_empty() {
+                                    true => None,
+                                    false => Some(key.to_string().into()),
+                                }
+                            })
+                        }),
+                )
+            }
+            Some(Ok((Token::Text(_), remaining))) => CompletionResult::new(remaining, true),
+            Some(Ok((Token::Attribute(_), _))) => CompletionResult::new(input, false),
+            Some(Err(_)) => CompletionResult::new_final(false),
+            None => CompletionResult::new_final(false).add_suggestions(
+                ctx.feeds
+                    .iter()
+                    .filter_map(FeedView::as_group)
+                    .map(|group| group.name.to_string().into()),
+            ),
+        }
+    }
+}

--- a/hedgehog-tui/src/main.rs
+++ b/hedgehog-tui/src/main.rs
@@ -9,6 +9,7 @@ mod options;
 mod screen;
 mod scrolling;
 mod theming;
+mod utils;
 mod widgets;
 
 use actix::prelude::*;

--- a/hedgehog-tui/src/main.rs
+++ b/hedgehog-tui/src/main.rs
@@ -1,3 +1,4 @@
+mod cmdcontext;
 mod cmdreader;
 mod environment;
 mod events;

--- a/hedgehog-tui/src/screen.rs
+++ b/hedgehog-tui/src/screen.rs
@@ -29,8 +29,8 @@ use hedgehog_library::search::{self, SearchClient, SearchResult};
 use hedgehog_library::status_writer::{self, StatusWriter, StatusWriterCommand};
 use hedgehog_library::{
     EpisodePlaybackDataRequest, EpisodeSummariesRequest, EpisodesListMetadataRequest,
-    EpisodesQuery, FeedSummariesRequest, FeedUpdateNotification, FeedUpdateRequest,
-    FeedUpdateResult, Library, NewFeedMetadata, UpdateQuery,
+    EpisodesQuery, FeedSummariesRequest, FeedSummariesResponse, FeedUpdateNotification,
+    FeedUpdateRequest, FeedUpdateResult, Library, NewFeedMetadata, UpdateQuery,
 };
 use hedgehog_player::state::PlaybackState;
 use hedgehog_player::volume::VolumeCommand;
@@ -912,16 +912,16 @@ impl UI {
         ctx.spawn(
             wrap_future(self.library_actor.send(FeedSummariesRequest)).map(
                 move |data, actor: &mut UI, ctx| match data {
-                    Ok(data) => {
+                    Ok(FeedSummariesResponse { feeds, groups: _ }) => {
                         actor
                             .library
                             .feeds
                             .update_data::<selection::FindPrevious, _>(|current_feeds| {
-                                let mut feeds = Vec::with_capacity(data.len() + 2);
-                                feeds.push(FeedView::All);
-                                feeds.push(FeedView::New);
-                                feeds.extend(data.into_iter().map(FeedView::Feed));
-                                *current_feeds = feeds;
+                                let mut feed_views = Vec::with_capacity(feeds.len() + 2);
+                                feed_views.push(FeedView::All);
+                                feed_views.push(FeedView::New);
+                                feed_views.extend(feeds.into_iter().map(FeedView::Feed));
+                                *current_feeds = feed_views;
                             });
                         actor.update_current_feed(ctx);
                         actor.library.feeds_loaded = true;

--- a/hedgehog-tui/src/screen.rs
+++ b/hedgehog-tui/src/screen.rs
@@ -1367,7 +1367,16 @@ impl Handler<FeedUpdateNotification> for UI {
             FeedUpdateNotification::FeedAdded(feed) => {
                 self.library
                     .feeds
-                    .update_data::<selection::Keep, _>(|feeds, _| feeds.push(FeedView::Feed(feed)));
+                    .update_data::<selection::Keep, _>(|feeds, _| {
+                        let mut index = 0;
+                        while index < feeds.len() {
+                            if let FeedView::Group(_) = feeds[index] {
+                                break;
+                            }
+                            index += 1;
+                        }
+                        feeds.insert(index, FeedView::Feed(feed));
+                    });
                 self.update_current_feed(ctx);
             }
             FeedUpdateNotification::FeedDeleted(feed_id) => {

--- a/hedgehog-tui/src/scrolling/mod.rs
+++ b/hedgehog-tui/src/scrolling/mod.rs
@@ -91,6 +91,10 @@ impl<D: DataView> ScrollableList<D> {
         self.data.item_at(self.viewport.selected_index())
     }
 
+    pub(crate) fn selected_index(&self) -> usize {
+        self.viewport.selected_index()
+    }
+
     pub(crate) fn has_item_at_window_row(&self, index: usize) -> bool {
         let offset = self.viewport.range().next();
         offset

--- a/hedgehog-tui/src/utils.rs
+++ b/hedgehog-tui/src/utils.rs
@@ -1,0 +1,24 @@
+use std::iter::Peekable;
+
+pub(crate) fn iter_take_while<'a, T, I: Iterator<Item = T>, F: Fn(&T) -> bool + 'a>(
+    iter: &'a mut Peekable<I>,
+    predicate: F,
+) -> impl Iterator<Item = T> + 'a {
+    TakeWhile { iter, predicate }
+}
+
+struct TakeWhile<'a, I: Iterator, F> {
+    iter: &'a mut Peekable<I>,
+    predicate: F,
+}
+
+impl<'a, I: Iterator, F: Fn(&I::Item) -> bool + 'a> Iterator for TakeWhile<'a, I, F> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter.peek() {
+            Some(item) if (self.predicate)(item) => self.iter.next(),
+            Some(_) | None => None,
+        }
+    }
+}

--- a/hedgehog-tui/src/widgets/feed_row.rs
+++ b/hedgehog-tui/src/widgets/feed_row.rs
@@ -143,9 +143,9 @@ impl<'t, 'a> ListItemRenderingDelegate<'a> for FeedsListRowRenderer<'t> {
                 let paragraph = Paragraph::new(item.title.as_str());
                 paragraph.render(
                     Rect::new(
-                        area.x + 1,
+                        area.x + 2,
                         area.y,
-                        area.width.saturating_sub(2),
+                        area.width.saturating_sub(3),
                         area.height,
                     ),
                     buf,

--- a/hedgehog-tui/src/widgets/feed_row.rs
+++ b/hedgehog-tui/src/widgets/feed_row.rs
@@ -1,7 +1,7 @@
 use super::{layout::split_right, list::ListItemRenderingDelegate};
 use crate::options::Options;
 use crate::theming::{self, Theme};
-use hedgehog_library::model::{FeedId, FeedStatus, FeedSummary, FeedView};
+use hedgehog_library::model::{FeedId, FeedStatus, FeedSummary, FeedView, GroupSummary};
 use std::collections::HashSet;
 use tui::buffer::Buffer;
 use tui::layout::Rect;
@@ -63,13 +63,13 @@ impl<'t> FeedsListRowRenderer<'t> {
 }
 
 impl<'t, 'a> ListItemRenderingDelegate<'a> for FeedsListRowRenderer<'t> {
-    type Item = (&'a FeedView<FeedSummary>, bool);
+    type Item = (&'a FeedView<FeedSummary, GroupSummary>, bool);
 
     fn render_item(&self, mut area: Rect, item: Self::Item, buf: &mut tui::buffer::Buffer) {
         let (item, selected) = item;
 
         match item {
-            FeedView::All | FeedView::New => {
+            FeedView::All | FeedView::New | FeedView::Group(_) => {
                 let item_selector = theming::ListItem {
                     selected,
                     focused: self.focused,
@@ -85,6 +85,7 @@ impl<'t, 'a> ListItemRenderingDelegate<'a> for FeedsListRowRenderer<'t> {
                 let paragraph = Paragraph::new(match item {
                     FeedView::All => "All episodes",
                     FeedView::New => "New",
+                    FeedView::Group(group) => &group.name,
                     FeedView::Feed(_) => unreachable!(),
                 });
                 paragraph.render(

--- a/hedgehog-tui/src/widgets/library.rs
+++ b/hedgehog-tui/src/widgets/library.rs
@@ -84,11 +84,11 @@ impl<'a> Widget for LibraryWidget<'a> {
                 .feeds
                 .data()
                 .item_at(selected_feed_index)
-                .map(|item| item.as_ref().map(|feed| feed.status));
+                .map(|item| item.as_ref().map_feed(|feed| feed.status));
 
             if self.data.episodes.data().size() == 0 {
                 match state {
-                    Some(FeedView::All) => {}
+                    Some(FeedView::All | FeedView::Group(_)) => {}
                     Some(FeedView::New) => {
                         EmptyView::new(self.theme)
                             .title("There are no new episodes.")


### PR DESCRIPTION
This PR allows grouping of feeds in the sidebar into groups. There are now several new and updated commands:

* `add-group` Create new group at the end of the list
* `set-group` Adds a feed into a group
* `place-group` Changes the order of groups
* `rename` Renames a feed or a group
* `delete` Can now delete groups as well as feeds