### PR TITLE
Fix build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,29 @@ build/
 
 .envrc
 /hedgehog.1.html
+
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.extensionOutputFolder": "./.vscode"
-}

--- a/hedgehog-library/src/status_writer.rs
+++ b/hedgehog-library/src/status_writer.rs
@@ -22,21 +22,21 @@ impl StatusWriter {
     }
 
     pub fn set_playing_path(mut self, path: PathBuf) -> Self {
-        (self.playing_path, self.saved_episode_id) = match fs::File::open(&path) {
+        self.saved_episode_id = match fs::File::open(&path) {
             Ok(file) => {
                 let mut buffer = String::new();
                 if let Err(err) = BufReader::new(file).read_line(&mut buffer) {
                     log::error!(target:"io", "Cannot load previous playback status: {}", err);
-                    (None, None)
+                    None
                 } else {
                     let id = buffer.trim_end().parse::<i64>().ok().map(EpisodeId);
-                    (Some(path), id)
+                    id
                 }
             }
-            Err(err) if err.kind() == ErrorKind::NotFound => (Some(path), None),
+            Err(err) if err.kind() == ErrorKind::NotFound => None,
             Err(err) => {
                 log::error!(target:"io", "Cannot load previous playback status: {}", err);
-                (None, None)
+                None
             }
         };
         self


### PR DESCRIPTION
Received this error when building on Linux:
```
error[E0658]: destructuring assignments are unstable
  --> hedgehog-library/src/status_writer.rs:25:52
   |
25 |         (self.playing_path, self.saved_episode_id) = match fs::File::open(&path) {
   |         ------------------------------------------ ^
   |         |
   |         cannot assign to this expression
   |
   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
```

Fix was to move the assignments of `playing_path` and `saved_episode_id`. This is a lot less pretty but it works for me now.